### PR TITLE
Prop changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Added `value` and `name` props to make checkbox act more like a real HTML5 checkbox. Previously
+name was generated from `id` prop.
 
 ## 1.4.2pm 
 * Fixed a styling issue that only occurred in Firefox

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | checked                  | boolean          | false                                    | Is checked or not                        |
 | className                | string           |                                          | Additional class for component           |
 | disabled                 | boolean          | false                                    | Is disabled                              |
-| id                       | string           |                                          | ID                                       |
+| id                       | string           |                                          | ID attribute. Resulting element ID will be `${id}-checkbox`                                       |
+| name                     | string           |                                          | Name attribute                           |
+| value                    | string           |                                          | Value attribute                          |
 | label                    | string or node   |                                          | Checkbox label                           |
 | tabIndex                 | string           | 0                                        | tabIndex                                 |
 

--- a/src/checkbox.component.jsx
+++ b/src/checkbox.component.jsx
@@ -13,6 +13,8 @@ export default class Checkbox extends React.PureComponent {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     id: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.string,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,
@@ -32,6 +34,8 @@ export default class Checkbox extends React.PureComponent {
     },
     inputRef: null,
     tabIndex: null,
+    name: null,
+    value: null,
   };
 
   constructor() {
@@ -58,17 +62,18 @@ export default class Checkbox extends React.PureComponent {
 
   renderCheckbox = (className) => {
     const {
-      checked, disabled, id, label, tabIndex,
+      checked, disabled, id, label, tabIndex, name, value,
     } = this.props;
 
     return (
       <label
-        htmlFor={`${this.props.id}-checkbox`}
+        htmlFor={`${id}-checkbox`}
         className={className}
       >
         <input
           type="checkbox"
-          name={id}
+          name={name}
+          value={value}
           id={`${id}-checkbox`}
           checked={checked}
           disabled={disabled}

--- a/src_docs/components/example.component.jsx
+++ b/src_docs/components/example.component.jsx
@@ -14,13 +14,15 @@ export default class ComponentView extends React.PureComponent {
   }
 
   onCheckboxChange = (e) => {
-    this.setState({ [e.target.name]: e.target.checked });
+    this.setState({ [e.target.value]: e.target.checked });
   };
 
   getCheckboxes = () => {
     const checkboxes = ['Checked', 'Unnamed', 'Unchecked', 'Disabled'];
     return checkboxes.map(box => ({
-      id: box.toLowerCase(),
+      id: `${box.toLowerCase()}-checkbox`,
+      value: box.toLowerCase(),
+      name: 'boxes',
       label: box,
       disabled: box === 'Disabled',
     }));
@@ -34,8 +36,10 @@ export default class ComponentView extends React.PureComponent {
             <Checkbox
               onChange={this.onCheckboxChange}
               id={checkbox.id}
+              name={checkbox.name}
+              value={checkbox.value}
               label={checkbox.label}
-              checked={this.state[checkbox.id]}
+              checked={this.state[checkbox.value]}
               key={checkbox.id}
               disabled={checkbox.disabled}
             />


### PR DESCRIPTION
Added `value` and `name` props to make checkbox act more like a real HTML5 checkbox. Previously
name was generated from `id` prop.